### PR TITLE
Added build-for-mac.sh script in demo/ for macOS Catalina

### DIFF
--- a/demo/build-for-macos.sh
+++ b/demo/build-for-macos.sh
@@ -1,0 +1,15 @@
+git clone https://github.com/panda3d/panda3d
+# xcode-select --install # uncomment this if you don't have Command Line Tools installedls
+export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/openssl/lib
+cd panda3d
+python3 makepanda/makepanda.py --everything --no-python
+ln -s demo/panda3d/built/include ../../include
+# ln -s demo/panda3d/built/lib ../../lib # seems like this will lead to shader errors
+cd ..
+sed s/mill-scene\"/mill-scene.egg\"/g src/main.cxx | tee src/main.tmp.cxx
+mv src/main.tmp.cxx src/main.cxx
+g++ -c src/main.cxx -Ipanda3d/built/include -o main.o -std=c++14 -O2
+g++ main.o -o main -Lpanda3d/built/lib -lpanda -lp3framework -lpandafx -lpandaexpress -lp3dtoolconfig -lp3dtool -lp3direct -lpthread -lpandaegg -lp3openal_audio -lpandagl
+mkdir ../lib
+cd panda3d/built/lib
+cp -r libp3direct.1.11.dylib libp3framework.1.11.dylib libpandafx.1.11.dylib libpanda.1.11.dylib libp3dtool.1.11.dylib libpandaegg.1.11.dylib libpandagl.a libp3dtoolconfig.1.11.dylib libpandaexpress.1.11.dylib libp3openal_audio.dylib libpandagl.dylib ../../../../lib


### PR DESCRIPTION
As Panda3D [couldn't be installed from the installer in macOS Catalina](https://github.com/panda3d/panda3d/issues/760) these days, I wrote this build script to clone the repository down, build Panda3D, __then__ build this project. It might be buggy and it requires the current workdir to be in demo/.

## Prerequisite

You need to have the following stuffs installed:

- Xcode Command Line Tools (`xcode-select --install`)
- Python3
- sed
- clang++ (and its alias `g++` - GNU/G++ might not work.)

## How can I use this?

Simply cd into demo and run, ignoring all errors all the way (if there are any):

```sh
cd demo
sh build-for-macos.sh
```

The executable will be named `main`. So to execute:

```sh
./main
```

This script is quite ugly and I am just making it work right now. If there are any bugs or improvements to be made, please tell me! Thanks!

Here's a screenshot of it actually running. There are a bunch of warnings, but it works!:

<img width="1217" alt="Capture d’écran 2019-12-23 à 11 44 38 PM" src="https://user-images.githubusercontent.com/4988733/71366879-3d526980-25de-11ea-8dae-d84ee9716da7.png">
