### PR TITLE
update readme to mention python 2.7

### DIFF
--- a/sections/building-the-demo.md
+++ b/sections/building-the-demo.md
@@ -14,6 +14,12 @@ Before you can try out the demo program, you'll have to build the example code f
 
 ### Dependencies
 
+#### Python 2.7
+
+Ensure your python version is 2.7.
+
+#### Panda3D
+
 Before you can compile the example code, you'll need to install
 [Panda3D](https://www.panda3d.org/)
 for your platform.


### PR DESCRIPTION
My setup with conda env, panda3d were for python 3 until I read further down and the build instructions assume python 2.7. I think it is worth mentioning python 2.7 up front as a dependency.